### PR TITLE
feature boss data reward data

### DIFF
--- a/Assets/Data.meta
+++ b/Assets/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 995232e1fc020b748bdfd61c18b8f595
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Boss.meta
+++ b/Assets/Data/Boss.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8da59ec9381ee3641a7264fb218f3ec5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Boss/CrownData.asset
+++ b/Assets/Data/Boss/CrownData.asset
@@ -9,12 +9,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 25858c48d0793e447906cf2fbbda2fe5, type: 3}
-  m_Name: 1stageEnemy 3
-  m_EditorClassIdentifier: Assembly-CSharp::EnemyData
-  enemyName: a
-  maxHp: 23
-  attackPower: 1
+  m_Script: {fileID: 11500000, guid: b47fde0b2858aca49899bd87d1e4f90c, type: 3}
+  m_Name: CrownData
+  m_EditorClassIdentifier: Assembly-CSharp::BossDataSo
+  enemyName: Crown
+  maxHp: 50
+  attackPower: 20
   enemyImage: {fileID: 4801227835787818748, guid: fcc2587eedde71f45baef9b8eeb215ba, type: 3}
   skillPrefab: {fileID: 9003740594294720738, guid: 832d0254706b8e14a8126bdf74c16c52, type: 3}
   rewardData: {fileID: 11400000, guid: ce76f0f718cd0c44dabcaba08ffc6c50, type: 2}
+  hasGimmick: 1

--- a/Assets/Data/Boss/CrownData.asset.meta
+++ b/Assets/Data/Boss/CrownData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec47eadbe94124845a62b2bbf8a28529
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Reward.meta
+++ b/Assets/Data/Reward.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ba34cc2654a6d241a7a394ff0e7abf7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Reward/1Layer_Reward.asset
+++ b/Assets/Data/Reward/1Layer_Reward.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc01316a4d32713449dceadc4819282a, type: 3}
+  m_Name: 1Layer_Reward
+  m_EditorClassIdentifier: Assembly-CSharp::RewardDataSo
+  clearGold: 10
+  rewardPool: []
+  rewardCount: 3

--- a/Assets/Data/Reward/1Layer_Reward.asset.meta
+++ b/Assets/Data/Reward/1Layer_Reward.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce76f0f718cd0c44dabcaba08ffc6c50
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefab/Managers/BattleDataManager.prefab
+++ b/Assets/Prefab/Managers/BattleDataManager.prefab
@@ -1,0 +1,49 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6322686787336117716
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1237078768470438365}
+  - component: {fileID: 5464591921284174581}
+  m_Layer: 0
+  m_Name: BattleDataManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1237078768470438365
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6322686787336117716}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.92058, y: -0.96543, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5464591921284174581
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6322686787336117716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9957b9ff28c78c943901a4f662886a4e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::BattleDataManager
+  currentEnemyData: {fileID: 0}
+  isBossBattle: 0
+  currentRewardData: {fileID: 0}

--- a/Assets/Prefab/Managers/BattleDataManager.prefab.meta
+++ b/Assets/Prefab/Managers/BattleDataManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ca885674b73cc584f8ea92c972251c95
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/MapDataSo/MapDataSo.asset
+++ b/Assets/Resources/MapDataSo/MapDataSo.asset
@@ -12,7 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 748cac4df78547d44a40b86c56144824, type: 3}
   m_Name: MapDataSo
   m_EditorClassIdentifier: Assembly-CSharp::MapDataSo
-  startLayerEnemies: []
+  startLayerEnemies:
+  - {fileID: 11400000, guid: 105055c6a003c384d985177f94854d6b, type: 2}
   layers:
   - nodeTypeWeights:
     - nodeType: 0
@@ -50,4 +51,4 @@ MonoBehaviour:
     - {fileID: 11400000, guid: dfdf95d6c26f3e0469ae197272bb1a37, type: 2}
     - {fileID: 11400000, guid: 6936ac57087ee1c4da7d100750bd967b, type: 2}
     - {fileID: 11400000, guid: 7c6ef847d0eeffd4fbf3d19523f9508b, type: 2}
-  bossEnemyData: {fileID: 0}
+  bossEnemyData: {fileID: 11400000, guid: ec47eadbe94124845a62b2bbf8a28529, type: 2}

--- a/Assets/Resources/MapDataSo/MapDataSo.asset
+++ b/Assets/Resources/MapDataSo/MapDataSo.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 748cac4df78547d44a40b86c56144824, type: 3}
   m_Name: MapDataSo
   m_EditorClassIdentifier: Assembly-CSharp::MapDataSo
+  startLayerEnemies: []
   layers:
   - nodeTypeWeights:
     - nodeType: 0
@@ -20,6 +21,11 @@ MonoBehaviour:
       weight: 2
     - nodeType: 2
       weight: 1
+    enemies:
+    - {fileID: 11400000, guid: 105055c6a003c384d985177f94854d6b, type: 2}
+    - {fileID: 11400000, guid: dfdf95d6c26f3e0469ae197272bb1a37, type: 2}
+    - {fileID: 11400000, guid: 6936ac57087ee1c4da7d100750bd967b, type: 2}
+    - {fileID: 11400000, guid: 7c6ef847d0eeffd4fbf3d19523f9508b, type: 2}
   - nodeTypeWeights:
     - nodeType: 0
       weight: 6
@@ -27,6 +33,11 @@ MonoBehaviour:
       weight: 2
     - nodeType: 2
       weight: 2
+    enemies:
+    - {fileID: 11400000, guid: 105055c6a003c384d985177f94854d6b, type: 2}
+    - {fileID: 11400000, guid: dfdf95d6c26f3e0469ae197272bb1a37, type: 2}
+    - {fileID: 11400000, guid: 6936ac57087ee1c4da7d100750bd967b, type: 2}
+    - {fileID: 11400000, guid: 7c6ef847d0eeffd4fbf3d19523f9508b, type: 2}
   - nodeTypeWeights:
     - nodeType: 0
       weight: 0
@@ -34,3 +45,9 @@ MonoBehaviour:
       weight: 7
     - nodeType: 2
       weight: 3
+    enemies:
+    - {fileID: 11400000, guid: 105055c6a003c384d985177f94854d6b, type: 2}
+    - {fileID: 11400000, guid: dfdf95d6c26f3e0469ae197272bb1a37, type: 2}
+    - {fileID: 11400000, guid: 6936ac57087ee1c4da7d100750bd967b, type: 2}
+    - {fileID: 11400000, guid: 7c6ef847d0eeffd4fbf3d19523f9508b, type: 2}
+  bossEnemyData: {fileID: 0}

--- a/Assets/Resources/StageData/1stageEnemy 1.asset
+++ b/Assets/Resources/StageData/1stageEnemy 1.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   attackPower: 1
   enemyImage: {fileID: 4801227835787818748, guid: fcc2587eedde71f45baef9b8eeb215ba, type: 3}
   skillPrefab: {fileID: 9003740594294720738, guid: 832d0254706b8e14a8126bdf74c16c52, type: 3}
+  rewardData: {fileID: 11400000, guid: ce76f0f718cd0c44dabcaba08ffc6c50, type: 2}

--- a/Assets/Resources/StageData/1stageEnemy 2.asset
+++ b/Assets/Resources/StageData/1stageEnemy 2.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   attackPower: 1
   enemyImage: {fileID: 4801227835787818748, guid: fcc2587eedde71f45baef9b8eeb215ba, type: 3}
   skillPrefab: {fileID: 9003740594294720738, guid: 832d0254706b8e14a8126bdf74c16c52, type: 3}
+  rewardData: {fileID: 11400000, guid: ce76f0f718cd0c44dabcaba08ffc6c50, type: 2}

--- a/Assets/Resources/StageData/1stageEnemy.asset
+++ b/Assets/Resources/StageData/1stageEnemy.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   attackPower: 1
   enemyImage: {fileID: 4801227835787818748, guid: fcc2587eedde71f45baef9b8eeb215ba, type: 3}
   skillPrefab: {fileID: 9003740594294720738, guid: 832d0254706b8e14a8126bdf74c16c52, type: 3}
+  rewardData: {fileID: 11400000, guid: ce76f0f718cd0c44dabcaba08ffc6c50, type: 2}

--- a/Assets/Scenes/BootStrap.unity
+++ b/Assets/Scenes/BootStrap.unity
@@ -164,11 +164,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::GameBootstrap
   sceneControlPrefab: {fileID: 822639163992330441, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
-  playerManagerPrefab: {fileID: 8729036687543461648, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-  playerShopManagerPrefab: {fileID: 3218232283522243185, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
   audioManagerPrefab: {fileID: 7528108071998853804, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
   settingsManagerPrefab: {fileID: 1723131241955938791, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
   playerStatsManagerPrefab: {fileID: 855262972402716990, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
+  battleDataManagerPrefab: {fileID: 6322686787336117716, guid: ca885674b73cc584f8ea92c972251c95, type: 3}
 --- !u!1 &2058177989
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameBoard.unity
+++ b/Assets/Scenes/GameBoard.unity
@@ -119,71 +119,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &7328943
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 824.44855
-      objectReference: {fileID: 0}
-    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 493.65085
-      objectReference: {fileID: 0}
-    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7410325421691265432, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: ShopLevel
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7410325421691265432, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: playerImage
-      value: 
-      objectReference: {fileID: 5232074664630632540, guid: b25181ffb71a87340bb931816e0f4f21, type: 3}
-    - target: {fileID: 8729036687543461648, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
-      propertyPath: m_Name
-      value: PlayerManager
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
 --- !u!1 &9821793
 GameObject:
   m_ObjectHideFlags: 0
@@ -7394,6 +7329,63 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 376842212}
   m_CullTransparentMesh: 1
+--- !u!1001 &377082878
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.58552
+      objectReference: {fileID: 0}
+    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 18.2805
+      objectReference: {fileID: 0}
+    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5033588502839095353, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8729036687543461648, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
+      propertyPath: m_Name
+      value: PlayerManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 570d6b02797570f4a8839fdfc3a957e7, type: 3}
 --- !u!1 &377299822
 GameObject:
   m_ObjectHideFlags: 0
@@ -11437,171 +11429,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 614382095}
   m_CullTransparentMesh: 1
---- !u!1001 &621709620
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1723131241955938791, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_Name
-      value: SettingsManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 4212248816314985585, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 947.83356
-      objectReference: {fileID: 0}
-    - target: {fileID: 4212248816314985585, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 589.599
-      objectReference: {fileID: 0}
-    - target: {fileID: 4212248816314985585, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4212248816314985585, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4212248816314985585, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4212248816314985585, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4212248816314985585, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4212248816314985585, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4212248816314985585, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4212248816314985585, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4536207016182116178, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_Pivot.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4536207016182116178, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_Pivot.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4536207016182116178, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4536207016182116178, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4536207016182116178, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4536207016182116178, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4536207016182116178, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 4536207016182116178, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 70
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 70
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7761934009303892113, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7843417733738842601, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 2684601575855638078, guid: 2f426a4709204ad4da5cf0dc654ff628, type: 3}
-    - target: {fileID: 7843417733738842601, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_Color.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7843417733738842601, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_Color.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7843417733738842601, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_Color.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7843417733738842601, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7927287852970381347, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 236a30ab0a589ce4995ebef2f05de0e1, type: 3}
 --- !u!1 &622368397
 GameObject:
   m_ObjectHideFlags: 0
@@ -18299,75 +18126,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 706264772}
   m_CullTransparentMesh: 1
---- !u!1001 &706551916
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 505672611328661063, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 947.83356
-      objectReference: {fileID: 0}
-    - target: {fileID: 505672611328661063, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 589.599
-      objectReference: {fileID: 0}
-    - target: {fileID: 505672611328661063, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 505672611328661063, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 505672611328661063, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 505672611328661063, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 505672611328661063, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 505672611328661063, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 505672611328661063, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 505672611328661063, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3713288751761694685, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: sfxClips.Array.size
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3713288751761694685, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: 'sfxClips.Array.data[3]'
-      value: 
-      objectReference: {fileID: 8300000, guid: 93bdda81e6426c9488f0bc4fd36ca0b3, type: 3}
-    - target: {fileID: 3713288751761694685, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: 'sfxClips.Array.data[4]'
-      value: 
-      objectReference: {fileID: 8300000, guid: d332a94fb6f314046ab62c7a67541863, type: 3}
-    - target: {fileID: 7528108071998853804, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
-      propertyPath: m_Name
-      value: AudioManager
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ac62b12995cdcb0408b1edfe1dea98c9, type: 3}
 --- !u!1 &712548582
 GameObject:
   m_ObjectHideFlags: 0
@@ -45336,63 +45094,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1468008583}
   m_CullTransparentMesh: 1
---- !u!1001 &1478319278
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 822639163992330441, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
-      propertyPath: m_Name
-      value: SceneControl
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042848813934587794, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 947.83356
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042848813934587794, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 589.599
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042848813934587794, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042848813934587794, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042848813934587794, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042848813934587794, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042848813934587794, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042848813934587794, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042848813934587794, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4042848813934587794, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b45573705cb4e749ad05b205b65768f, type: 3}
 --- !u!1 &1480444429
 GameObject:
   m_ObjectHideFlags: 0
@@ -46744,6 +46445,63 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1567472212}
   m_CullTransparentMesh: 1
+--- !u!1001 &1582306846
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.58552
+      objectReference: {fileID: 0}
+    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 18.2805
+      objectReference: {fileID: 0}
+    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3218232283522243185, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
+      propertyPath: m_Name
+      value: PlayerShopManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
 --- !u!1 &1588241413
 GameObject:
   m_ObjectHideFlags: 0
@@ -49160,63 +48918,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 10
   m_TargetDisplay: 0
---- !u!1001 &1718167171
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 855262972402716990, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
-      propertyPath: m_Name
-      value: PlayerStatsData
-      objectReference: {fileID: 0}
-    - target: {fileID: 4065923248427251525, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 947.83356
-      objectReference: {fileID: 0}
-    - target: {fileID: 4065923248427251525, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 589.599
-      objectReference: {fileID: 0}
-    - target: {fileID: 4065923248427251525, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4065923248427251525, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4065923248427251525, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4065923248427251525, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4065923248427251525, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4065923248427251525, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4065923248427251525, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4065923248427251525, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 554aafaab026bd645b0298ea74c05baf, type: 3}
 --- !u!1 &1719176085
 GameObject:
   m_ObjectHideFlags: 0
@@ -59574,87 +59275,6 @@ MonoBehaviour:
   bounceHeight: 35
   holdDuration: 1
   outroFadeDuration: 0.4
---- !u!1001 &2064335120
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 947.83356
-      objectReference: {fileID: 0}
-    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 589.599
-      objectReference: {fileID: 0}
-    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1352461017581481096, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3218232283522243185, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: m_Name
-      value: PlayerShopManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 3218232283522243185, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6549974157846703604, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: shopPanel
-      value: 
-      objectReference: {fileID: 633769864}
-    - target: {fileID: 6549974157846703604, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: shopCanvas
-      value: 
-      objectReference: {fileID: 308558009}
-    - target: {fileID: 6549974157846703604, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: shopAnimator
-      value: 
-      objectReference: {fileID: 633769867}
-    - target: {fileID: 6549974157846703604, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: shopUIController
-      value: 
-      objectReference: {fileID: 957840217}
-    - target: {fileID: 6549974157846703604, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
-      propertyPath: shopPanelAnimator
-      value: 
-      objectReference: {fileID: 633769867}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 11c6721714c606a41af6bafb391d9454, type: 3}
 --- !u!1 &2069003458
 GameObject:
   m_ObjectHideFlags: 0
@@ -62381,15 +62001,11 @@ SceneRoots:
   - {fileID: 1876421105}
   - {fileID: 1948593662}
   - {fileID: 474977918}
-  - {fileID: 7328943}
-  - {fileID: 2064335120}
-  - {fileID: 706551916}
-  - {fileID: 1718167171}
-  - {fileID: 1478319278}
-  - {fileID: 621709620}
   - {fileID: 1206205768}
   - {fileID: 100594583}
   - {fileID: 1101827776}
   - {fileID: 642861948}
   - {fileID: 794785513}
   - {fileID: 33635709}
+  - {fileID: 377082878}
+  - {fileID: 1582306846}

--- a/Assets/Script/Core/PlayerManager.cs
+++ b/Assets/Script/Core/PlayerManager.cs
@@ -18,7 +18,6 @@ public class PlayerManager : MonoBehaviour
     public bool isFirstRoll;
     public bool isGameOver;
     public Sprite playerImage;
-    public EnemyData currentEnemyData;
 
     private const int DiceSlotCount = 6;
     private const int ItemSlotCount = 7;

--- a/Assets/Script/Core/PlayerManager.cs
+++ b/Assets/Script/Core/PlayerManager.cs
@@ -18,6 +18,7 @@ public class PlayerManager : MonoBehaviour
     public bool isFirstRoll;
     public bool isGameOver;
     public Sprite playerImage;
+    public EnemyData currentEnemyData;
 
     private const int DiceSlotCount = 6;
     private const int ItemSlotCount = 7;

--- a/Assets/Script/Core/SceneController.cs
+++ b/Assets/Script/Core/SceneController.cs
@@ -155,12 +155,17 @@ public class SceneController : MonoBehaviour
     {
         if (fadeCanvasGroup == null) return;
 
+        float elapsed = 0f;
         fadeCanvasGroup.alpha = from;
         fadeCanvasGroup.blocksRaycasts = true;
 
-        var tween = fadeCanvasGroup.DOFade(to, fadeDuration).SetLink(fadeCanvasGroup.gameObject).SetEase(Ease.Linear);
-
-        await tween.AsyncWaitForCompletion();
+        while (elapsed < fadeDuration)
+        {
+            if (fadeCanvasGroup == null) return; 
+            elapsed += Time.unscaledDeltaTime;
+            fadeCanvasGroup.alpha = Mathf.Lerp(from, to, elapsed / fadeDuration);
+            await UniTask.Yield();
+        }
 
         fadeCanvasGroup.alpha = to;
         fadeCanvasGroup.blocksRaycasts = to > 0f;

--- a/Assets/Script/Data/BaseEnemyData.cs
+++ b/Assets/Script/Data/BaseEnemyData.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+public abstract class BaseEnemyData : ScriptableObject
+{
+    public string enemyName;
+    public int maxHp;
+    public int attackPower;
+    public Sprite enemyImage;
+    public GameObject skillPrefab;
+    // 패턴, 드롭 아이템 등 나중에 확장
+    [Header("보상")]
+    public RewardDataSo rewardData;
+}

--- a/Assets/Script/Data/BaseEnemyData.cs.meta
+++ b/Assets/Script/Data/BaseEnemyData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b5d56609ceb5d9b489e25d1f5f006714

--- a/Assets/Script/Data/BossDataSo.cs
+++ b/Assets/Script/Data/BossDataSo.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+[CreateAssetMenu(fileName = "BossDataSo", menuName = "Battle/BossDataSo")]
+public class BossDataSo : BaseEnemyData
+{
+    [Header("±â¹Í")]
+    public bool hasGimmick;
+}

--- a/Assets/Script/Data/BossDataSo.cs.meta
+++ b/Assets/Script/Data/BossDataSo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b47fde0b2858aca49899bd87d1e4f90c

--- a/Assets/Script/Data/RewardDataSo.cs
+++ b/Assets/Script/Data/RewardDataSo.cs
@@ -1,0 +1,78 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+public enum RewardType
+{
+    Gold,
+    Dice,
+    HpPotion,
+    PassiveItem,
+    ActiveItem
+}
+
+[System.Serializable]
+public class RewardData
+{
+    public RewardType rewardType;
+    public int weight;
+
+    public DiceData dice;
+    public int goldAmount;
+    public int healAmount;
+    public ItemSo item;
+}
+
+[CreateAssetMenu(fileName = "RewardDataSo", menuName = "Battle/RewardDataSo")]
+public class RewardDataSo : ScriptableObject
+{
+    [Header("라운드 종료 후 골드 보상")]
+    public int clearGold;
+
+    [Header("선택 보상")]
+    public List<RewardData> rewardPool;
+    public int rewardCount = 3;
+
+    public RewardData GetRandomReward(List<RewardData> exclude = null)
+    {
+        List<RewardData> candidates = new List<RewardData>();
+
+        foreach(var reward in rewardPool)
+        {
+            if (exclude != null && exclude.Contains(reward)) continue;
+            candidates.Add(reward);
+        }
+
+        if (candidates.Count == 0) return null;
+
+        int totalWeight = 0;
+        foreach (var reward in candidates)
+            totalWeight += reward.weight;
+
+        int random = Random.Range(0, totalWeight);
+        int current = 0;
+
+        foreach(var reward in candidates)
+        {
+            current += reward.weight;
+            if (random < current)
+                return reward;
+        }
+
+        return null;
+    }
+
+    public List<RewardData> GetRewards(int count)
+    {
+        List<RewardData> result = new List<RewardData>();
+
+        for(int i = 0; i < count; i++)
+        {
+            RewardData reward = GetRandomReward(result);
+            if (reward != null)
+                result.Add(reward);
+        }
+        return result;
+    }
+}
+
+

--- a/Assets/Script/Data/RewardDataSo.cs.meta
+++ b/Assets/Script/Data/RewardDataSo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fc01316a4d32713449dceadc4819282a

--- a/Assets/Script/GamePlay/Round/RoundManager.cs
+++ b/Assets/Script/GamePlay/Round/RoundManager.cs
@@ -63,28 +63,13 @@ public class RoundManager : MonoBehaviour
         {
             roundEffect.PlayIntroAnim(currentRound);
 
-            if (currentStageData != null)
-            {
-                RoundData roundData = currentStageData.GetRoundData(currentRound);
+            EnemyData enemy = PlayerManager.instance?.currentEnemyData;
 
-                if(roundData != null)
-                {
-                    if(currentRound % 5 == 1)
-                    {
-                        GimmickManager.instance?.PreparePendingGimmick(currentRound);
-                        UpdateEnemyImage();
-                    }
-                    else if(currentRound % 5 != 0)
-                    {
-                        UpdateEnemyImage();
-                    }
+            if (enemy != null)
+            {    
+                if (enemyImage != null && enemy.enemyImage != null)                       
+                    enemyImage.sprite = enemy.enemyImage;
 
-                    if (roundData.hasGimmick)
-                    {
-                        UpdateEnemyImage();
-                        GimmickManager.instance.ApplyPendingGimmick(currentRound);
-                    }
-                }
             }
             else
             {
@@ -121,18 +106,6 @@ public class RoundManager : MonoBehaviour
         }
     }
 
-    private void UpdateEnemyImage()
-    {
-        if (enemyImage == null || currentStageData == null) return;
-        if (GimmickManager.instance == null) return;
-
-        GimmickType type = GimmickManager.instance.GetPendingMainGimmickType();
-        EnemyData enemyData = currentStageData.GetEnemyDataByGimmick(type);
-
-        if (enemyData != null && enemyData.enemyImage != null)
-            enemyImage.sprite = enemyData.enemyImage;
-    }
-
     public void CompleteRound(bool isSuccess)
     {
         if (UiController.instance != null) UiController.instance.SetRollBtnInteractable(false);
@@ -161,6 +134,8 @@ public class RoundManager : MonoBehaviour
         }
 
         int currentHP = PlayerManager.instance != null ? PlayerManager.instance.heart : 0;
+
+        // 클리어 시 선택 보상
 
         if(isSuccess)
         {

--- a/Assets/Script/GamePlay/Round/RoundManager.cs
+++ b/Assets/Script/GamePlay/Round/RoundManager.cs
@@ -62,19 +62,12 @@ public class RoundManager : MonoBehaviour
         else
         {
             roundEffect.PlayIntroAnim(currentRound);
-
-            EnemyData enemy = PlayerManager.instance?.currentEnemyData;
-
-            if (enemy != null)
-            {    
-                if (enemyImage != null && enemy.enemyImage != null)                       
-                    enemyImage.sprite = enemy.enemyImage;
-
-            }
-            else
+            if (enemyImage != null)
             {
-                Debug.LogWarning($"{currentRound}라운드 정보가 없습니다.");
+                enemyImage.sprite = BattleDataManager.instance?.GetEnemyImage();
             }
+
+            // 보스전만 기믹
         }
 
         if (GameManager.instance != null)
@@ -108,7 +101,8 @@ public class RoundManager : MonoBehaviour
 
     public void CompleteRound(bool isSuccess)
     {
-        if (UiController.instance != null) UiController.instance.SetRollBtnInteractable(false);
+        if (UiController.instance != null) 
+            UiController.instance.SetRollBtnInteractable(false);
 
         if(PlayerManager.instance != null)
         {
@@ -139,31 +133,20 @@ public class RoundManager : MonoBehaviour
 
         if(isSuccess)
         {
-            if(currentStageData != null && GameManager.instance != null)
+            int reward = BattleDataManager.instance?.GetGoldReward() ?? 10;
+            GameManager.instance.AddGold(reward);
+
+            // 보스전 클리어 후 맵 데이터 초기화
+            if(BattleDataManager.instance?.isBossBattle == true)
             {
-                int reward = currentStageData.GetGoldRewardForSuccess(currentRound);
-                GameManager.instance.AddGold(reward);
-                Debug.Log($"라운드 성공! 골드 {reward} 획득");
+                MapManager.instance?.ClearMapSave();
+                BattleDataManager.instance?.Clear();
             }
             UiController.instance.ShowResultPanel(true, currentHP);
         }
         else
         {
-
-            if(currentHP > 0)
-            {
-                if (currentStageData != null && GameManager.instance != null)
-                {
-                    int reward = currentStageData.GetGoldRewardForFailure(currentRound);
-                    GameManager.instance.AddGold(reward);
-                    Debug.Log($"라운드 실패 골드 {reward} 획득");
-                }
-                UiController.instance.ShowResultPanel(false, currentHP);
-            }
-            else
-            {
-                GameManager.instance.HandleGameOver();
-            }
+            GameManager.instance.HandleGameOver();
         }
         GimmickManager.instance.ClearGimmick();
     }

--- a/Assets/Script/Map/MapDataSo.cs
+++ b/Assets/Script/Map/MapDataSo.cs
@@ -12,13 +12,20 @@ public class NodeTypeWeight
 public class LayerConfig
 {
     public List<NodeTypeWeight> nodeTypeWeights;
+    public List<EnemyData> enemies;
 }
 
 [CreateAssetMenu(fileName = "MapDataSo", menuName = "Stage/MapDataSo")]
 public class MapDataSo : ScriptableObject
 {
-    [Header("레이더 설정")]
+    [Header("1층 설정")]
+    public List<EnemyData> startLayerEnemies;
+
+    [Header("중간 레이어 설정")]
     public List<LayerConfig> layers= new List<LayerConfig>();
+
+    [Header("보스 데이터 설정")]
+    public EnemyData bossEnemyData;
 
     public NodeType GetRandomNodeType(LayerConfig config)
     {
@@ -51,6 +58,7 @@ public class MapDataSo : ScriptableObject
             layer = 0,
             xIndex = 0,
             nodeType = NodeType.Battle,
+            enemyDataIndex = GetRandomEnemyIndexFromIndex(startLayerEnemies)
         };
         nodes.Add(startNode);
         allLayers.Add(new List<MapNodeData> { startNode });
@@ -68,7 +76,8 @@ public class MapDataSo : ScriptableObject
                     id = idCounter++,
                     layer = i,
                     xIndex = j,
-                    nodeType = GetRandomNodeType(config)
+                    nodeType = GetRandomNodeType(config),
+                    enemyDataIndex = GetRandomEnemyIndex(config)
                 };
                 layerNodes.Add(node);
                 nodes.Add(node);
@@ -76,6 +85,7 @@ public class MapDataSo : ScriptableObject
             allLayers.Add(layerNodes);
         }
 
+        // 보스레이어
         MapNodeData bossNode = new MapNodeData
         {
             id = idCounter++,
@@ -89,6 +99,7 @@ public class MapDataSo : ScriptableObject
         ConnectNodes(allLayers);
         return nodes;
     }
+
     private void ConnectNodes(List<List<MapNodeData>> allLayers)
     {
         int totalOneToTwo = 0;
@@ -191,5 +202,16 @@ public class MapDataSo : ScriptableObject
         if (totalOneToTwo == 0) return 0.65f;
         if (totalOneToTwo == 1) return 0.2f;
         return 0.05f;
+    }
+    private int GetRandomEnemyIndex(LayerConfig config)
+    {
+        if (config.enemies == null || config.enemies.Count == 0) return 0;
+        return Random.Range(0, config.enemies.Count);
+    }
+
+    private int GetRandomEnemyIndexFromIndex(List<EnemyData> enemies)
+    {
+        if (enemies == null || enemies.Count == 0) return 0;
+        return Random.Range(0, enemies.Count);
     }
 }

--- a/Assets/Script/Map/MapDataSo.cs
+++ b/Assets/Script/Map/MapDataSo.cs
@@ -25,7 +25,7 @@ public class MapDataSo : ScriptableObject
     public List<LayerConfig> layers= new List<LayerConfig>();
 
     [Header("보스 데이터 설정")]
-    public EnemyData bossEnemyData;
+    public BossDataSo bossEnemyData;
 
     public NodeType GetRandomNodeType(LayerConfig config)
     {

--- a/Assets/Script/Map/MapManager.cs
+++ b/Assets/Script/Map/MapManager.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 public class MapManager : MonoBehaviour
 {
@@ -208,6 +209,30 @@ public class MapManager : MonoBehaviour
         {
             case NodeType.Battle:
             case NodeType.Boss:
+                MapNodeData selectedNode = _generateNodes.Find(n => n.id == _previousNodeId);
+                if(selectedNode != null)
+                {
+                    if(selectedNode.nodeType == NodeType.Boss)
+                    {
+                        PlayerManager.instance.currentEnemyData = mapData.bossEnemyData;
+                    }
+                    else if (selectedNode.layer == 0)
+                    {
+                        var enemies = mapData.startLayerEnemies;
+                        if (enemies != null && enemies.Count > selectedNode.enemyDataIndex)
+                            PlayerManager.instance.currentEnemyData = enemies[selectedNode.enemyDataIndex];
+                    }
+                    else
+                    {
+                        int layerIndex = selectedNode.layer = -1;
+                        if(layerIndex >= 0 && layerIndex < mapData.layers.Count)
+                        {
+                            var enemies = mapData.layers[layerIndex].enemies;
+                            if (enemies != null && enemies.Count > selectedNode.enemyDataIndex)
+                                PlayerManager.instance.currentEnemyData = enemies[selectedNode.enemyDataIndex];
+                        }
+                    }
+                }
                 SceneController.instance?.LoadGameScene();
                 break;
             case NodeType.Shop:

--- a/Assets/Script/Map/MapManager.cs
+++ b/Assets/Script/Map/MapManager.cs
@@ -208,31 +208,32 @@ public class MapManager : MonoBehaviour
         switch(nodeType)
         {
             case NodeType.Battle:
-            case NodeType.Boss:
                 MapNodeData selectedNode = _generateNodes.Find(n => n.id == _previousNodeId);
                 if(selectedNode != null)
                 {
-                    if(selectedNode.nodeType == NodeType.Boss)
-                    {
-                        PlayerManager.instance.currentEnemyData = mapData.bossEnemyData;
-                    }
-                    else if (selectedNode.layer == 0)
+                    EnemyData enemy = null;
+                    if(selectedNode.layer == 0)
                     {
                         var enemies = mapData.startLayerEnemies;
-                        if (enemies != null && enemies.Count > selectedNode.enemyDataIndex)
-                            PlayerManager.instance.currentEnemyData = enemies[selectedNode.enemyDataIndex];
+                        if(enemies != null && enemies.Count > selectedNode.enemyDataIndex)
+                            enemy = enemies[selectedNode.enemyDataIndex];
                     }
                     else
                     {
-                        int layerIndex = selectedNode.layer = -1;
-                        if(layerIndex >= 0 && layerIndex < mapData.layers.Count)
+                        int layerIndex = selectedNode.layer - 1;
+                        if (layerIndex >= 0 && layerIndex < mapData.layers.Count)
                         {
                             var enemies = mapData.layers[layerIndex].enemies;
                             if (enemies != null && enemies.Count > selectedNode.enemyDataIndex)
-                                PlayerManager.instance.currentEnemyData = enemies[selectedNode.enemyDataIndex];
+                                enemy = enemies[selectedNode.enemyDataIndex];
                         }
                     }
+                    BattleDataManager.instance?.SetBattleData(enemy);
                 }
+                SceneController.instance?.LoadGameScene();
+                break;
+            case NodeType.Boss:
+                BattleDataManager.instance?.SetBossBattleData(mapData.bossEnemyData);
                 SceneController.instance?.LoadGameScene();
                 break;
             case NodeType.Shop:

--- a/Assets/Script/Map/MapNodeData.cs
+++ b/Assets/Script/Map/MapNodeData.cs
@@ -9,4 +9,6 @@ public class MapNodeData
     public int layer;
     public int xIndex;
     public List<int> nextNodeIDs = new List<int>();
+    //적 데이터
+    public int enemyDataIndex = 0;
 }

--- a/Assets/Script/System/GameBootstrap.cs
+++ b/Assets/Script/System/GameBootstrap.cs
@@ -8,7 +8,7 @@ public class GameBootstrap : MonoBehaviour
     [SerializeField] private GameObject audioManagerPrefab;
     [SerializeField] private GameObject settingsManagerPrefab;
     [SerializeField] private GameObject playerStatsManagerPrefab;
-
+    [SerializeField] private GameObject battleDataManagerPrefab;
     private async UniTask Start()
     {
         Instantiate(playerStatsManagerPrefab);
@@ -21,6 +21,9 @@ public class GameBootstrap : MonoBehaviour
         await UniTask.NextFrame();
 
         Instantiate(sceneControlPrefab);
+        await UniTask.NextFrame();
+
+        Instantiate(battleDataManagerPrefab);
         await UniTask.NextFrame();
 
         if (!VaildateManagers()) return;
@@ -50,6 +53,11 @@ public class GameBootstrap : MonoBehaviour
         if (AudioManager.instance == null)
         {
             Debug.LogError("AudioManager 초기화 실패");
+            return false;
+        }
+        if (BattleDataManager.instance == null)
+        {
+            Debug.LogError("BattleDataManager 초기화 실패");
             return false;
         }
         return true;

--- a/Assets/Script/Woriking/2/EnemyData.cs
+++ b/Assets/Script/Woriking/2/EnemyData.cs
@@ -1,12 +1,7 @@
 using UnityEngine;
 
 [CreateAssetMenu(menuName = "Battle/EnemyData")]
-public class EnemyData : ScriptableObject
+public class EnemyData : BaseEnemyData
 {
-    public string enemyName;
-    public int maxHp;
-    public int attackPower;
-    public Sprite enemyImage;
-    public GameObject skillPrefab;
-    // 패턴, 드롭 아이템 등 나중에 확장
+    // 상속
 }

--- a/Assets/Script/Woriking/BattleDataManager.cs
+++ b/Assets/Script/Woriking/BattleDataManager.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+
+public class BattleDataManager : MonoBehaviour
+{
+    public static BattleDataManager instance;
+
+    [Header("전투 데이터")]
+    public BaseEnemyData currentEnemyData;
+    public bool isBossBattle;
+
+    [Header("보상 데이터")]
+    public RewardDataSo currentRewardData;
+
+    private void Awake()
+    {
+        if (instance == null)
+        {
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else Destroy(gameObject);
+    }
+
+    public void SetBattleData(EnemyData enemyData)
+    {
+        currentEnemyData = enemyData;
+        isBossBattle = false;
+        currentRewardData = enemyData.rewardData;
+    }
+
+    public void SetBossBattleData(BossDataSo bossData)
+    {
+        currentEnemyData = bossData;
+        isBossBattle = true;
+        currentRewardData = bossData.rewardData;
+    }
+
+    public void Clear()
+    {
+        currentEnemyData = null;
+        currentRewardData = null;
+        isBossBattle = false;
+    }
+
+    public int GetEnemyMaxHp()
+    {
+        return currentEnemyData?.maxHp ?? 0;
+    }
+
+    public Sprite GetEnemyImage()
+    {
+        return currentEnemyData?.enemyImage;
+    }
+
+    public bool hasGimmick()
+    {
+        if (!isBossBattle) return false;
+        return (currentEnemyData as BossDataSo)?.hasGimmick ?? false;
+    }
+
+    public int GetGoldReward()
+    {
+        return currentRewardData?.clearGold ?? 10;
+    }
+}
+

--- a/Assets/Script/Woriking/BattleDataManager.cs.meta
+++ b/Assets/Script/Woriking/BattleDataManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9957b9ff28c78c943901a4f662886a4e

--- a/Assets/Script/Woriking/BattleManager.cs
+++ b/Assets/Script/Woriking/BattleManager.cs
@@ -62,16 +62,15 @@ public class BattleManager : MonoBehaviour
         _battleCts?.Dispose();
         _battleCts = new CancellationTokenSource();
 
-        EnemyData enemy = PlayerManager.instance?.currentEnemyData;
-
-        if(enemy == null)
+        // 배틀 데이터 매니저에서 불러오게끔 변경
+        if(BattleDataManager.instance == null || BattleDataManager.instance.GetEnemyMaxHp() == 0)
         {
-            Debug.LogWarning("currentEnemyData가 없습니다.");
+            Debug.LogWarning("BattleDataManager 또는 적 최대 HP 데이터가 없습니다.");
             return;
         }
 
-        enemyData.Initialize(enemy);
-
+ 
+        enemyData.Initialize(BattleDataManager.instance.currentEnemyData);
         playerData.Initialize(playerSO);
 
         battleUI.UpdateEnemyHP(enemyData.CurrentHP, enemyData.MaxHp);
@@ -307,11 +306,9 @@ public class BattleManager : MonoBehaviour
         }
 
 
-        EnemyData enemy = PlayerManager.instance?.currentEnemyData;
-
-        if(enemy == null)
+        if(BattleDataManager.instance == null || BattleDataManager.instance.GetEnemyMaxHp() == 0)
         {
-            Debug.Log("currentEnemyData 없음");
+            Debug.LogWarning("BattleDataManager 데이터 없음");
             SaveManager.instance.Delete(BATTLE_SAVE_FILE);
             return;
         }
@@ -319,7 +316,7 @@ public class BattleManager : MonoBehaviour
 
         // 데이터 복원
         playerData.Initialize(playerSO, data.playerCurrentHP);
-        enemyData.Initialize(enemy, data.enemyMaxHP);
+        enemyData.Initialize(BattleDataManager.instance.currentEnemyData, data.enemyMaxHP);
 
         isPlayerTurn = data.isPlayerTurn;
         isBattleActive = data.isBattleActive;

--- a/Assets/Script/Woriking/BattleManager.cs
+++ b/Assets/Script/Woriking/BattleManager.cs
@@ -55,33 +55,35 @@ public class BattleManager : MonoBehaviour
 
     public void InitializeBattle()
     {
-        if (RoundManager.instance == null || RoundManager.instance.currentStageData == null)
+        if (RoundManager.instance == null)
             return;
 
         _battleCts?.Cancel();
         _battleCts?.Dispose();
         _battleCts = new CancellationTokenSource();
 
-        RoundData roundData = RoundManager.instance.currentStageData.GetRoundData(
-            RoundManager.instance.currentRound
-        );
+        EnemyData enemy = PlayerManager.instance?.currentEnemyData;
 
-        if (roundData != null && roundData.enemyData != null)
+        if(enemy == null)
         {
-            enemyData.Initialize(roundData.enemyData);
-
-            playerData.Initialize(playerSO);
-
-            battleUI.UpdateEnemyHP(enemyData.CurrentHP, enemyData.MaxHp);
-            battleUI.UpdatePlayerHP(playerData.CurrentHP, playerData.MaxHp);
-
-            isPlayerTurn = true;
-            isBattleActive = true;
-            currentTurn = 1;
-
-            //StartNewTurn();
-            SaveBattleData();
+            Debug.LogWarning("currentEnemyData가 없습니다.");
+            return;
         }
+
+        enemyData.Initialize(enemy);
+
+        playerData.Initialize(playerSO);
+
+        battleUI.UpdateEnemyHP(enemyData.CurrentHP, enemyData.MaxHp);
+        battleUI.UpdatePlayerHP(playerData.CurrentHP, playerData.MaxHp);
+
+        isPlayerTurn = true;
+        isBattleActive = true;
+        currentTurn = 1;
+
+        //StartNewTurn();
+        SaveBattleData();
+
 
         enemyDamage = CalculateEnemyAttackPower();
         battleUI.UpdateEnemyAttackAmount(enemyDamage);
@@ -304,13 +306,20 @@ public class BattleManager : MonoBehaviour
             return;
         }
 
-        BattleSaveData data = SaveManager.instance.Load<BattleSaveData>(BATTLE_SAVE_FILE);
 
-        RoundData roundData = RoundManager.instance.currentStageData.GetRoundData(data.currentBattleRound);
+        EnemyData enemy = PlayerManager.instance?.currentEnemyData;
+
+        if(enemy == null)
+        {
+            Debug.Log("currentEnemyData 없음");
+            SaveManager.instance.Delete(BATTLE_SAVE_FILE);
+            return;
+        }
+        BattleSaveData data = SaveManager.instance.Load<BattleSaveData>(BATTLE_SAVE_FILE);
 
         // 데이터 복원
         playerData.Initialize(playerSO, data.playerCurrentHP);
-        enemyData.Initialize(roundData.enemyData, data.enemyMaxHP);
+        enemyData.Initialize(enemy, data.enemyMaxHP);
 
         isPlayerTurn = data.isPlayerTurn;
         isBattleActive = data.isBattleActive;

--- a/Assets/Script/Woriking/BattleSaveData.cs
+++ b/Assets/Script/Woriking/BattleSaveData.cs
@@ -10,7 +10,7 @@ public class BattleSaveData
     [Header("Enemy Data")]
     public int enemyCurrentHP;
     public int enemyMaxHP;
-    public string enemyName = "";
+    //public string enemyName = ""; -> EnemyBattleData에서 참조하므로 저장할 필요 없음
 
     [Header("Battle State")]
     public bool isPlayerTurn = true;

--- a/Assets/Script/Woriking/EnemyBattleData.cs
+++ b/Assets/Script/Woriking/EnemyBattleData.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 [System.Serializable]
 public class EnemyBattleData : IDamageable
 {
-    private EnemyData _data;  // 원본 참조
+    private BaseEnemyData _data;  // 원본 참조
     private int currentHP;
     private List<StatusEffect> statusEffects = new();  // 번, 독 등
 
@@ -13,14 +13,14 @@ public class EnemyBattleData : IDamageable
     public int CurrentHP => currentHP;
     public IReadOnlyList<StatusEffect> StatusEffects => statusEffects;
 
-    public void Initialize(EnemyData data)
+    public void Initialize(BaseEnemyData data)
     {
         _data = data;
         currentHP = data.maxHp;
         statusEffects.Clear();
     }
 
-    public void Initialize(EnemyData data, int savedHP)
+    public void Initialize(BaseEnemyData data, int savedHP)
     {
         _data = data;
         currentHP = savedHP;
@@ -52,7 +52,7 @@ public class EnemyBattleData : IDamageable
         }
     }
 
-    // 추가 - 적 턴 시작마다 호출
+    // 추가 - 적 턴 시작마다 호출 
     public void ProcessTurnStart()
     {
         foreach (var effect in statusEffects)


### PR DESCRIPTION
bossData, rewardData 추가
층마다 rewardData 설정 가능

enemyData -> baseEnemyData를 만들어서 적의 기본데이터를 상속해서 새로운 적을 생성하는 방식으로 적 데이터 수정

battleDataManager 추가 -> 적 데이터를 관리하는 매니저 추가
dontdestory 형태로 만듦
map에서 노드를 선택하면 적이 결정 되고 적을 gameBoard에 전달하는 역할도 가지고 있음
